### PR TITLE
fix ruff lint errors (isort, E741)

### DIFF
--- a/src/arc/cli.py
+++ b/src/arc/cli.py
@@ -1247,8 +1247,8 @@ def ping_cmd(
 @app.command("version")
 def version_cmd() -> None:
     """Print arc version."""
-    from pathlib import Path
     import re
+    from pathlib import Path
 
     # Read directly from pyproject.toml so git pull alone updates the version
     pyproject = Path(__file__).parent.parent.parent / "pyproject.toml"

--- a/src/arc/discord_bridge.py
+++ b/src/arc/discord_bridge.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import discord
 from discord import app_commands
 
-from arc.agents import load_agent, list_agents, resolve_agent_for_channel
+from arc.agents import list_agents, load_agent, resolve_agent_for_channel
 from arc.config import ArcConfig
 from arc.utils import split_message
 
@@ -161,7 +161,7 @@ class ArcDiscordBot(discord.Client):
             if not log_path.exists():
                 await interaction.response.send_message("No routing log found.", ephemeral=True)
                 return
-            raw = [l for l in log_path.read_text().strip().splitlines() if l][-last:]
+            raw = [line for line in log_path.read_text().strip().splitlines() if line][-last:]
             if not raw:
                 await interaction.response.send_message("No history yet.", ephemeral=True)
                 return

--- a/tests/test_discord_bridge.py
+++ b/tests/test_discord_bridge.py
@@ -499,7 +499,7 @@ async def test_cron_run(config_dir: Path) -> None:
 
 
 async def test_cron_next(config_dir: Path) -> None:
-    from datetime import datetime, timezone, timedelta
+    from datetime import datetime, timedelta, timezone
     from types import SimpleNamespace
     bot, daemon = _make_bot()
     future = datetime.now(timezone.utc) + timedelta(hours=2)


### PR DESCRIPTION
## Background
Ruff lint CI was failing on `main` due to pre-existing violations, which surface on any new PR targeting `main`.

## Changes
- Sort imports in `src/arc/cli.py`, `src/arc/discord_bridge.py`, and `tests/test_discord_bridge.py` (I001)
- Rename ambiguous variable `l` to `line` in `discord_bridge.py` (E741)

## Testing Notes
`ruff check src/ tests/` passes cleanly.