### PR TITLE
chore: rename GitHub org from ia-eknorr to etknorr

### DIFF
--- a/.design/arc-builder.md
+++ b/.design/arc-builder.md
@@ -489,7 +489,7 @@ Database at `~/.arc-builder/memory.db`. Created by `setup.sh` on first run.
 CREATE TABLE IF NOT EXISTS projects (
     id          INTEGER PRIMARY KEY,
     name        TEXT UNIQUE NOT NULL,       -- "arc", "fitness-coach"
-    repo        TEXT NOT NULL,              -- "ia-eknorr/arc"
+    repo        TEXT NOT NULL,              -- "etknorr/arc"
     workspace   TEXT NOT NULL,              -- "/workspace/arc"
     language    TEXT,                       -- "python", "typescript"
     main_branch TEXT NOT NULL DEFAULT 'main',
@@ -504,7 +504,7 @@ CREATE TABLE IF NOT EXISTS decisions (
     project     TEXT,                       -- NULL = global
     decision    TEXT NOT NULL,
     rationale   TEXT,
-    issue_ref   TEXT,                       -- "ia-eknorr/arc#7"
+    issue_ref   TEXT,                       -- "etknorr/arc#7"
     created_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
@@ -868,7 +868,7 @@ otherwise it proceeds without one and notes its absence in the PR description.
 ### Phase 1: PM + issue creation (ship first, use immediately)
 
 Deliverables:
-- Create `ia-eknorr/arc-builder` repo
+- Create `etknorr/arc-builder` repo
 - Write PM identity files (IDENTITY.md, SOUL.md, AGENTS.md)
 - Write STANDARDS.md and PROJECTS.md for known projects
 - Initialize SQLite schema, populate `projects` table

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,6 @@
     "config:recommended"
   ],
   "reviewers": [
-    "ia-eknorr"
+    "etknorr"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **Shell completions** — Typer generates dynamic completions for zsh, bash, fish, and PowerShell via `arc --install-completion`.
 
-- **Docusaurus documentation site** — Full docs at `https://ia-eknorr.github.io/arc/` covering architecture, all CLI commands, agent/config/cron schema references, guides, and troubleshooting.
+- **Docusaurus documentation site** — Full docs at `https://etknorr.github.io/arc/` covering architecture, all CLI commands, agent/config/cron schema references, guides, and troubleshooting.
 
-[v0.2.0]: https://github.com/ia-eknorr/arc/releases/tag/v0.2.0
-[v0.1.0]: https://github.com/ia-eknorr/arc/releases/tag/v0.1.0
+[v0.2.0]: https://github.com/etknorr/arc/releases/tag/v0.2.0
+[v0.1.0]: https://github.com/etknorr/arc/releases/tag/v0.1.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 ia-eknorr
+Copyright (c) 2025 etknorr
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # arc
 
-[![Lint](https://github.com/ia-eknorr/arc/actions/workflows/lint.yml/badge.svg)](https://github.com/ia-eknorr/arc/actions/workflows/lint.yml)
-[![Unit Tests](https://github.com/ia-eknorr/arc/actions/workflows/test.yml/badge.svg)](https://github.com/ia-eknorr/arc/actions/workflows/test.yml)
-[![release](https://img.shields.io/github/v/release/ia-eknorr/arc?color=orange)](https://github.com/ia-eknorr/arc/releases)
+[![Lint](https://github.com/etknorr/arc/actions/workflows/lint.yml/badge.svg)](https://github.com/etknorr/arc/actions/workflows/lint.yml)
+[![Unit Tests](https://github.com/etknorr/arc/actions/workflows/test.yml/badge.svg)](https://github.com/etknorr/arc/actions/workflows/test.yml)
+[![release](https://img.shields.io/github/v/release/etknorr/arc?color=orange)](https://github.com/etknorr/arc/releases)
 [![license](https://img.shields.io/badge/license-MIT-brightgreen)](LICENSE)
-[![docs](https://img.shields.io/badge/docs-ia--eknorr.github.io-blue)](https://ia-eknorr.github.io/arc/)
+[![docs](https://img.shields.io/badge/docs-ia--eknorr.github.io-blue)](https://etknorr.github.io/arc/)
 
 A lightweight Python CLI and daemon for agent dispatch, scheduled tasks, and Discord integration. Replaces OpenClaw with minimal code, using `acpx` for Claude Code session management and `httpx` for Ollama.
 
@@ -26,7 +26,7 @@ A lightweight Python CLI and daemon for agent dispatch, scheduled tasks, and Dis
 ## Install
 
 ```bash
-git clone git@github.com:ia-eknorr/arc.git
+git clone git@github.com:etknorr/arc.git
 cd arc
 python3 -m venv venv
 source venv/bin/activate

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -4,7 +4,7 @@ title: Changelog
 sidebar_position: 1
 ---
 
-Full release notes are in [CHANGELOG.md](https://github.com/ia-eknorr/arc/blob/main/CHANGELOG.md) on GitHub.
+Full release notes are in [CHANGELOG.md](https://github.com/etknorr/arc/blob/main/CHANGELOG.md) on GitHub.
 
 ---
 
@@ -18,7 +18,7 @@ Full release notes are in [CHANGELOG.md](https://github.com/ia-eknorr/arc/blob/m
 - Graceful degradation when daemon is not running
 - LXC system service install documentation
 
-[v0.2.0]: https://github.com/ia-eknorr/arc/releases/tag/v0.2.0
+[v0.2.0]: https://github.com/etknorr/arc/releases/tag/v0.2.0
 
 ---
 
@@ -37,4 +37,4 @@ Full release notes are in [CHANGELOG.md](https://github.com/ia-eknorr/arc/blob/m
 - Shell completions for zsh, bash, fish, and PowerShell
 - Docusaurus documentation site
 
-[v0.1.0]: https://github.com/ia-eknorr/arc/releases/tag/v0.1.0
+[v0.1.0]: https://github.com/etknorr/arc/releases/tag/v0.1.0

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -48,7 +48,7 @@ pip install arc-cli
 For development (editable install with test dependencies):
 
 ```bash
-git clone git@github.com:ia-eknorr/arc.git
+git clone git@github.com:etknorr/arc.git
 cd arc
 pip install -e ".[dev]"
 ```
@@ -58,7 +58,7 @@ pip install -e ".[dev]"
 For headless server installs (LXC, VM, cloud instance), a shell script handles Python environment setup, directory creation, and optional systemd service registration:
 
 ```bash
-git clone git@github.com:ia-eknorr/arc.git
+git clone git@github.com:etknorr/arc.git
 cd arc
 bash scripts/install.sh
 ```

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -6,9 +6,9 @@ const config: Config = {
   title: 'arc',
   tagline: 'Lightweight agent dispatch, scheduling, and Discord integration',
   favicon: 'img/logo.svg',
-  url: 'https://ia-eknorr.github.io',
+  url: 'https://etknorr.github.io',
   baseUrl: '/arc/',
-  organizationName: 'ia-eknorr',
+  organizationName: 'etknorr',
   projectName: 'arc',
   deploymentBranch: 'gh-pages',
   trailingSlash: false,
@@ -21,7 +21,7 @@ const config: Config = {
       docs: {
         sidebarPath: './sidebars.ts',
         routeBasePath: '/',
-        editUrl: 'https://github.com/ia-eknorr/arc/edit/main/docs/',
+        editUrl: 'https://github.com/etknorr/arc/edit/main/docs/',
       },
       blog: false,
       theme: {customCss: './src/css/custom.css'},
@@ -45,7 +45,7 @@ const config: Config = {
       logo: {alt: 'arc logo', src: 'img/logo.svg'},
       items: [
         {type: 'docSidebar', sidebarId: 'docs', position: 'left', label: 'Docs'},
-        {href: 'https://github.com/ia-eknorr/arc', label: 'GitHub', position: 'right'},
+        {href: 'https://github.com/etknorr/arc', label: 'GitHub', position: 'right'},
       ],
     },
     footer: {
@@ -63,7 +63,7 @@ const config: Config = {
         ]},
         {title: 'More', items: [
           {label: 'Changelog', to: '/changelog'},
-          {label: 'GitHub', href: 'https://github.com/ia-eknorr/arc'},
+          {label: 'GitHub', href: 'https://github.com/etknorr/arc'},
         ]},
       ],
       copyright: `Copyright © ${new Date().getFullYear()} arc. MIT License.`,


### PR DESCRIPTION
## Why

The GitHub username changed from `ia-eknorr` to `etknorr`. Stale references to the old org left the docs site misconfigured: the Docusaurus `url`/`organizationName` and every in-site GitHub link still pointed at `ia-eknorr.github.io` / `github.com/ia-eknorr/arc`, so links resolve to the old account and the GitHub Pages deploy targets the wrong canonical URL.

## What

Replace all `ia-eknorr` references with `etknorr`:

- `docs/docusaurus.config.ts` — `url`, `organizationName`, `editUrl`, navbar/footer GitHub links
- `README.md`, `CHANGELOG.md`, `docs/docs/changelog.md`, `docs/docs/getting-started/installation.md` — clone URLs, badges, release links
- `.github/renovate.json` — reviewer
- `LICENSE` — copyright holder
- `.design/arc-builder.md` — example repo references